### PR TITLE
Add iOS .gitignore with Theos build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Xcode
+build/
+DerivedData/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+
+# App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Objective-C specific
+*.hmap
+
+# Dependencies
+Pods/
+Carthage/Build/
+.build/
+
+# fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Theos build artifacts
+.theos/
+obj/
+_obj/
+*.deb
+*.o
+
+# macOS system files
+.DS_Store
+__MACOSX/
+.AppleDouble
+.LSOverride
+
+# Other system files
+*.swp
+*~
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- add standard Objective-C/.gitignore
- ignore Theos build outputs and common macOS files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae08f02d5483248843c2a5efe02231