### PR TITLE
Read target language from user defaults

### DIFF
--- a/TTTweak.xm
+++ b/TTTweak.xm
@@ -50,7 +50,14 @@ static TTOverlayView *TTGetOverlay(void) {
 
     TTOverlayView *overlay = TTGetOverlay();
     [overlay showOverlay];
-    [TTTranslate translateText:text toLanguage:@"en" completion:^(NSString * _Nullable translatedText, NSError * _Nullable error) {
+    // Retrieve the target language from user defaults. If no preference is set,
+    // fall back to the app's preferred localization (or English).
+    NSString *targetLang = [[NSUserDefaults standardUserDefaults] stringForKey:@"TTTargetLanguage"];
+    if (targetLang.length == 0) {
+        targetLang = [[NSBundle mainBundle] preferredLocalizations].firstObject ?: @"en";
+    }
+
+    [TTTranslate translateText:text toLanguage:targetLang completion:^(NSString * _Nullable translatedText, NSError * _Nullable error) {
         if (translatedText) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [overlay updateTranslatedText:translatedText];


### PR DESCRIPTION
## Summary
- read user selected language from defaults to drive translation
- default to app's preferred localization if none is set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e0bafe883249d5a8420e4f00b80