### PR TITLE
Auto-hide translation overlay after delay

### DIFF
--- a/TTTweak.xm
+++ b/TTTweak.xm
@@ -61,6 +61,9 @@ static TTOverlayView *TTGetOverlay(void) {
         if (translatedText) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [overlay updateTranslatedText:translatedText];
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [overlay hideOverlay];
+                });
             });
         }
     }];

--- a/src-objc/TTOverlayView.m
+++ b/src-objc/TTOverlayView.m
@@ -52,12 +52,22 @@
 
 - (void)showOverlay
 {
+    if (!self.hidden) return;
+    self.alpha = 0.0;
     self.hidden = NO;
+    [UIView animateWithDuration:0.25 animations:^{
+        self.alpha = 1.0;
+    }];
 }
 
 - (void)hideOverlay
 {
-    self.hidden = YES;
+    if (self.hidden) return;
+    [UIView animateWithDuration:0.25 animations:^{
+        self.alpha = 0.0;
+    } completion:^(BOOL finished) {
+        self.hidden = YES;
+    }];
 }
 
 @end


### PR DESCRIPTION
## Summary
- Add fade-in and fade-out animations for translation overlay
- Automatically hide overlay a few seconds after showing translated text

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ea2d0348324935e2e20616e9af5