### PR TITLE
Mock urllib in tests to avoid network calls

### DIFF
--- a/tests/test_translation_api.py
+++ b/tests/test_translation_api.py
@@ -1,6 +1,7 @@
 import json
 import urllib.request
 from urllib.parse import quote
+from unittest.mock import MagicMock, patch
 
 API_URL = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl={target}&dt=t&q={text}"
 
@@ -12,5 +13,11 @@ def translate(text: str, target: str) -> str:
     return data[0][0][0]
 
 def test_translate_hello_to_arabic():
-    translated = translate("hello", "ar")
-    assert "مرح" in translated
+    fake_payload = [[["مرحبا", "hello"]]]
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(fake_payload).encode("utf-8")
+    mock_response.__enter__.return_value = mock_response
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        translated = translate("hello", "ar")
+        assert translated == "مرحبا"
+        mock_urlopen.assert_called_once()


### PR DESCRIPTION
## Summary
- Mock `urllib.request.urlopen` in tests to provide a fake translation response
- Verify translation output and ensure no real network calls are made

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0fe06bc88324b7e17d4757a72e9a