### PR TITLE
Handle translation errors gracefully

### DIFF
--- a/TTTweak.xm
+++ b/TTTweak.xm
@@ -65,6 +65,13 @@ static TTOverlayView *TTGetOverlay(void) {
                     [overlay hideOverlay];
                 });
             });
+        } else if (error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [overlay updateTranslatedText:error.localizedDescription];
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [overlay hideOverlay];
+                });
+            });
         }
     }];
 }


### PR DESCRIPTION
## Summary
- Add error-handling branch in TTTweak to hide overlay on translation failures and display error message.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae199dab248324aca5b001dc21d926