### PR TITLE
Use NSURLComponents for safer query building

### DIFF
--- a/tests/test_translation_api.py
+++ b/tests/test_translation_api.py
@@ -21,3 +21,16 @@ def test_translate_hello_to_arabic():
         translated = translate("hello", "ar")
         assert translated == "مرحبا"
         mock_urlopen.assert_called_once()
+
+
+def test_translate_text_with_special_chars():
+    text = "a&b=c"
+    fake_payload = [[["X", text]]]
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(fake_payload).encode("utf-8")
+    mock_response.__enter__.return_value = mock_response
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        translated = translate(text, "ar")
+        assert translated == "X"
+        called_url = mock_urlopen.call_args[0][0]
+        assert "a%26b%3Dc" in called_url


### PR DESCRIPTION
## Summary
- Replace manual URL concatenation with NSURLComponents and query items for safer query building
- Enforce custom query character set excluding +&=?/ to properly encode user text
- Add regression test ensuring special characters in input are safely encoded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a8b1bbc8324995716dff90e6cd2