### PR TITLE
Add -ObjC linker flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TWEAK_NAME = TTTranslateKit
 TTTranslateKit_FILES = src-objc/TTTranslate.m src-objc/TTOverlayView.m TTTweak.xm
 TTTranslateKit_CFLAGS = -fobjc-arc
 TTTranslateKit_FRAMEWORKS = UIKit Foundation
+TTTranslateKit_LDFLAGS += -ObjC
 TTTranslateKit_LIBRARIES = c++
 
 include $(THEOS_MAKE_PATH)/tweak.mk


### PR DESCRIPTION
## Summary
- ensure Objective-C categories load by linking with `-ObjC`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae24ee70a48324bdbc36eed1495682