### PR TITLE
Hide overlay on translation failure

### DIFF
--- a/TTTweak.xm
+++ b/TTTweak.xm
@@ -65,6 +65,10 @@ static TTOverlayView *TTGetOverlay(void) {
                     [overlay hideOverlay];
                 });
             });
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [overlay hideOverlay];
+            });
         }
     }];
 }


### PR DESCRIPTION
## Summary
- Hide translation overlay when translation fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae2709e3bc8324a83da8d430e7374a