### PR TITLE
Use latest iOS SDK for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ARCHS = arm64
-TARGET = iphone:clang:15.5:13.0
+TARGET = iphone:clang:latest:13.0
 INSTALL_TARGET_PROCESSES = TikTok
 
 include $(THEOS)/makefiles/common.mk


### PR DESCRIPTION
## Summary
- use the latest iOS SDK in Theos target to avoid missing SDK errors

## Testing
- `pytest -q`
- `make clean package FINALPACKAGE=1` *(fails: `/tweak.mk: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae388b9b8083248b33a3a70001f1e2