### PR TITLE
ci: install ldid in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
           ln -sf "$SDK_PATH" "$HOME/theos/sdks/$(basename "$SDK_PATH")"
           ln -sf "$SDK_PATH" "$HOME/theos/sdks/iPhoneOS.sdk"
 
+      - name: Install ldid
+        run: brew install ldid
+
       - name: Install Theos submodules (safety)
         run: |
           cd $HOME/theos


### PR DESCRIPTION
## Summary
- install ldid using Homebrew in build workflow to ensure valid code signing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3955b0c483248145c5811a51a50d