### PR TITLE
Include CFNetwork framework in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include $(THEOS)/makefiles/common.mk
 TWEAK_NAME = TTTranslateKit
 TTTranslateKit_FILES = src-objc/TTTranslate.m src-objc/TTOverlayView.m TTTweak.xm
 TTTranslateKit_CFLAGS = -fobjc-arc
-TTTranslateKit_FRAMEWORKS = UIKit Foundation
+TTTranslateKit_FRAMEWORKS = UIKit Foundation CFNetwork
 TTTranslateKit_LDFLAGS += -ObjC
 TTTranslateKit_LIBRARIES = c++
 


### PR DESCRIPTION
## Summary
- Include CFNetwork alongside UIKit and Foundation in TTTranslateKit frameworks list to ensure network APIs link properly

## Testing
- `make clean package` *(fails: Makefile:14: /tweak.mk: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e763064832481b051334bdb83db