### PR TITLE
Remove c++ library from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,5 @@ TTTranslateKit_FILES = src-objc/TTTranslate.m src-objc/TTOverlayView.m TTTweak.x
 TTTranslateKit_CFLAGS = -fobjc-arc
 TTTranslateKit_FRAMEWORKS = UIKit Foundation CFNetwork
 TTTranslateKit_LDFLAGS += -ObjC
-TTTranslateKit_LIBRARIES = c++
 
 include $(THEOS_MAKE_PATH)/tweak.mk


### PR DESCRIPTION
## Summary
- remove unnecessary c++ library from tweak build

## Testing
- `make` *(fails: `/tweak.mk` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f3c5dcc832481858015a4f8d09b