### PR TITLE
Refactor overlay and translator interfaces into headers

### DIFF
--- a/TTTweak.xm
+++ b/TTTweak.xm
@@ -1,18 +1,6 @@
 #import <UIKit/UIKit.h>
-
-// Forward declarations for internal classes
-@interface TTOverlayView : UIView
-- (void)updateTranslatedText:(NSString *)text;
-- (void)showOverlay;
-- (void)hideOverlay;
-@end
-
-@interface TTTranslate : NSObject
-+ (void)translateText:(NSString *)text
-           toLanguage:(NSString *)targetLanguage
-           completion:(void(^)(NSString * _Nullable translatedText,
-                             NSError * _Nullable error))completion;
-@end
+#import "src-objc/TTOverlayView.h"
+#import "src-objc/TTTranslate.h"
 
 // Determine at runtime if we are running inside the target app.
 static BOOL TTIsTargetApp(void) {

--- a/src-objc/TTOverlayView.h
+++ b/src-objc/TTOverlayView.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+
+@interface TTOverlayView : UIView
+
+/// Updates the overlay with the provided translated text.
+- (void)updateTranslatedText:(NSString *)text;
+
+/// Shows the overlay.
+- (void)showOverlay;
+
+/// Hides the overlay.
+- (void)hideOverlay;
+
+@end

--- a/src-objc/TTOverlayView.m
+++ b/src-objc/TTOverlayView.m
@@ -1,18 +1,5 @@
 // TTOverlayView.m
-#import <UIKit/UIKit.h>
-
-@interface TTOverlayView : UIView
-
-/// Updates the overlay with the provided translated text.
-- (void)updateTranslatedText:(NSString *)text;
-
-/// Shows the overlay.
-- (void)showOverlay;
-
-/// Hides the overlay.
-- (void)hideOverlay;
-
-@end
+#import "TTOverlayView.h"
 
 @interface TTOverlayView ()
 

--- a/src-objc/TTTranslate.h
+++ b/src-objc/TTTranslate.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+@interface TTTranslate : NSObject
+
+/// Translates the provided text to the given target language.
+/// @param text The original text to translate.
+/// @param targetLanguage A language code such as "en" or "ar".
+/// @param completion Completion block returning translated text or an error.
++ (void)translateText:(NSString *)text
+           toLanguage:(NSString *)targetLanguage
+           completion:(void(^)(NSString * _Nullable translatedText,
+                             NSError * _Nullable error))completion;
+
+@end

--- a/src-objc/TTTranslate.m
+++ b/src-objc/TTTranslate.m
@@ -1,20 +1,4 @@
-#import <Foundation/Foundation.h>
-
-/// A simple translation utility that leverages a configurable translation
-/// endpoint (defaulting to the Google Translate API) to translate text from
-/// any source language to a specified target language.
-@interface TTTranslate : NSObject
-
-/// Translates the provided text to the given target language.
-/// @param text The original text to translate.
-/// @param targetLanguage A language code such as "en" or "ar".
-/// @param completion Completion block returning translated text or an error.
-+ (void)translateText:(NSString *)text
-           toLanguage:(NSString *)targetLanguage
-           completion:(void(^)(NSString * _Nullable translatedText,
-                             NSError * _Nullable error))completion;
-
-@end
+#import "TTTranslate.h"
 
 @implementation TTTranslate
 


### PR DESCRIPTION
## Summary
- Extract TTOverlayView and TTTranslate interfaces into dedicated Objective-C headers.
- Import new headers in tweak and implementation files, removing inline interface declarations.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae404638f48324972bcb81e9ddb9a9