### PR TITLE
Remove mocks from empty text translation test

### DIFF
--- a/tests/test_translation_api.py
+++ b/tests/test_translation_api.py
@@ -32,12 +32,8 @@ def test_translate_hello_to_arabic():
 
 
 def test_translate_empty_text_raises_error():
-    mock_response = MagicMock()
-    mock_response.read.return_value = json.dumps([[['', '']]]).encode("utf-8")
-    mock_response.__enter__.return_value = mock_response
-    with patch("urllib.request.urlopen", return_value=mock_response):
-        with pytest.raises(ValueError):
-            translate("", "ar")
+    with pytest.raises(ValueError):
+        translate("", "ar")
 
 
 def test_translate_url_error_propagates():


### PR DESCRIPTION
## Summary
- simplify empty text translation test by removing mocking and directly invoking `translate` with empty input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae417155e48324837d71f19863969b