### PR TITLE
chore: update CI workflow for dylib artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,19 +73,19 @@ jobs:
         working-directory: ${{ steps.find-project.outputs.dir }}
         run: make clean package FINALPACKAGE=1
 
-      - name: Extract dylib
+      - name: Extract dylib and plist
         working-directory: ${{ steps.find-project.outputs.dir }}
         run: |
           mkdir -p out
           DEB=$(ls packages/*.deb | head -n1)
           dpkg-deb -x "$DEB" extract
-          cp extract/Library/MobileSubstrate/DynamicLibraries/*.dylib out/
-          cp *.plist out/ || true
+          cp extract/Library/MobileSubstrate/DynamicLibraries/*.dylib out/TTTranslateKit.dylib
+          cp TTTranslateKit.plist out/TTTranslateKit.plist
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TTTranslateKit-artifact
+          name: TTTranslateKit-artifacts
           path: ${{ steps.find-project.outputs.dir }}/out/*
 
       - name: Create release


### PR DESCRIPTION
## Summary
- rename upload artifact to `TTTranslateKit-artifacts`
- explicitly output `TTTranslateKit.dylib` and `TTTranslateKit.plist`

## Testing
- `pytest -q`
- `git push origin main` *(fails: 'origin' does not appear to be a git repository)*
- `curl -L -X POST https://api.github.com/repos/mimo050/TTTranslateKit/actions/workflows/build.yml/dispatches -d '{"ref":"main"}'` *(fails: Must have admin rights to Repository)*
- `curl -L https://api.github.com/repos/mimo050/TTTranslateKit/actions/artifacts`

------
https://chatgpt.com/codex/tasks/task_e_68ae48ba605c8324b464d19aeaa2b50e