### PR TITLE
Refactor translation completion API

### DIFF
--- a/TTTweak.xm
+++ b/TTTweak.xm
@@ -38,14 +38,7 @@ static TTOverlayView *TTGetOverlay(void) {
 
     TTOverlayView *overlay = TTGetOverlay();
     [overlay showOverlay];
-    // Retrieve the target language from user defaults. If no preference is set,
-    // fall back to the app's preferred localization (or English).
-    NSString *targetLang = [[NSUserDefaults standardUserDefaults] stringForKey:@"TTTargetLanguage"];
-    if (targetLang.length == 0) {
-        targetLang = [[NSBundle mainBundle] preferredLocalizations].firstObject ?: @"en";
-    }
-
-    [TTTranslate translateText:text toLanguage:targetLang completion:^(NSString * _Nullable translatedText, NSError * _Nullable error) {
+    [TTTranslate translateText:text completion:^(NSString * _Nullable translatedText) {
         if (translatedText) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [overlay updateTranslatedText:translatedText];

--- a/src-objc/TTTranslate.h
+++ b/src-objc/TTTranslate.h
@@ -1,14 +1,17 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^TTTranslationCompletion)(NSString * _Nullable translatedText);
+
 @interface TTTranslate : NSObject
 
-/// Translates the provided text to the given target language.
+/// Translates the provided text to the user's preferred language.
 /// @param text The original text to translate.
-/// @param targetLanguage A language code such as "en" or "ar".
-/// @param completion Completion block returning translated text or an error.
-+ (void)translateText:(NSString *)text
-           toLanguage:(NSString *)targetLanguage
-           completion:(void(^)(NSString * _Nullable translatedText,
-                             NSError * _Nullable error))completion;
+/// @param completion Completion block returning translated text or `nil` on failure.
++ (void)translateText:(NSString * _Nullable)text
+           completion:(TTTranslationCompletion)completion;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary
- Use a dedicated `TTTranslationCompletion` block typedef and simplify translate API
- Return `nil` for empty input or errors and derive target language internally
- Update tweak hook to use new completion handler signature

## Testing
- `pytest -q`
- `make` *(fails: No such file or directory /tweak.mk)*

------
https://chatgpt.com/codex/tasks/task_e_68ae50c3ec108324bc6ee3e87472f05b