### PR TITLE
Configure Makefile build flags and frameworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ARCHS = arm64
+ARCHS := arm64
 TARGET = iphone:clang:latest:13.0
 INSTALL_TARGET_PROCESSES = TikTok
 
@@ -6,8 +6,9 @@ include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = TTTranslateKit
 TTTranslateKit_FILES = src-objc/TTTranslate.m src-objc/TTOverlayView.m TTTweak.xm
-TTTranslateKit_CFLAGS = -fobjc-arc
-TTTranslateKit_FRAMEWORKS = UIKit Foundation CFNetwork
-TTTranslateKit_LDFLAGS += -ObjC
+CFLAGS += -fobjc-arc -Wno-nullability-completeness -Wno-documentation
+LDFLAGS += -ObjC
+FRAMEWORKS += UIKit Foundation
+TTTranslateKit_FRAMEWORKS += CFNetwork
 
 include $(THEOS_MAKE_PATH)/tweak.mk


### PR DESCRIPTION
## Summary
- enforce arm64 architecture and apply ARC and ObjC linker flags
- include UIKit and Foundation frameworks and suppress nullability/documentation warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5228538483248f6d33da41a9baeb