### PR TITLE
ci: install ldid for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
           mkdir -p "$HOME/theos/sdks"
           ln -sf "$SDK_PATH" "$HOME/theos/sdks/iPhoneOS.sdk"
 
+      - name: Install ldid
+        run: brew install ldid
+
       - name: Build tweak
         env:
           THEOS: ${{ env.THEOS }}


### PR DESCRIPTION
## Summary
- install ldid in GitHub Actions workflow so Theos can sign binaries

## Testing
- `pytest`
- `make clean package FINALPACKAGE=1` *(fails: No rule to make target '/tweak.mk')*

------
https://chatgpt.com/codex/tasks/task_e_68ae5a1351308324b884f984df118acb