### PR TITLE
Add Debian packaging control and update CI artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           make clean package FINALPACKAGE=1
 
-      - name: Extract dylib and plist
+      - name: Extract files for artifact
         run: |
           mkdir -p out
           DEB=$(ls packages/*.deb | head -n1)
@@ -53,6 +53,8 @@ jobs:
           # عدّل المسار إذا اختلف اسم ملفك
           cp extract/Library/MobileSubstrate/DynamicLibraries/TTTranslateKit.dylib out/
           cp extract/Library/MobileSubstrate/DynamicLibraries/TTTranslateKit.plist out/
+          cp control out/
+          cp "$DEB" out/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ARCHS = arm64
 TARGET = iphone:clang:latest:13.0
 INSTALL_TARGET_PROCESSES = TikTok
+FINALPACKAGE = 1
 
 include $(THEOS)/makefiles/common.mk
 

--- a/control
+++ b/control
@@ -1,0 +1,9 @@
+Package: com.example.tttranslatekit
+Name: TTTranslateKit
+Version: 1.0.0
+Architecture: iphoneos-arm
+Description: Adds in-app translation feature for TikTok
+Maintainer: Example Maintainer <maintainer@example.com>
+Author: Example Maintainer <maintainer@example.com>
+Section: Tweaks
+Depends: mobilesubstrate


### PR DESCRIPTION
## Summary
- add Debian control file with package metadata for TTTranslateKit
- enable automatic deb packaging by setting `FINALPACKAGE = 1`
- include deb, control, dylib and plist in CI artifact output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5c608c308324bd9ef095c77f77e2