### PR TITLE
ci: upload dylib artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,12 @@ jobs:
         run: |
           make clean package FINALPACKAGE=1
 
+      - name: Upload dylib artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TTTranslateKit-dylib
+          path: packages/**/*.dylib
+
       - name: Extract files for artifact
         run: |
           set -e


### PR DESCRIPTION
## Summary
- upload built dylib as a standalone artifact

## Testing
- `~/.local/bin/yamllint .github/workflows/build.yml` *(fails: missing document start, line too long, syntax error, too many blank lines)*
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/build.yml` *(fails: YAML parse error at line 71)*

------
https://chatgpt.com/codex/tasks/task_e_68ae73b7b3708324a1bb9c2f7104b033