### PR TITLE
ci: use dpkg-deb only in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,6 @@ jobs:
           DEB=$(ls packages/*.deb | head -n1)
           echo "Found: $DEB"
           dpkg-deb -x "$DEB" out/extract
-          dpkg-deb -e "$DEB" out/control
           find out/extract -name "*.dylib" -print -exec cp {} out/ \;
           find out/extract -name "*.plist" -print -exec cp {} out/ \;
           cp "$DEB" out/


### PR DESCRIPTION
## Summary
- Use `dpkg-deb` only when extracting built packages in CI
- Drop unnecessary control extraction

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7c6179348324ab3785aad9addb9b